### PR TITLE
Do not put feed.xml on the website.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
   - gem update --system
 script:
   - JEKYLL_ENV=production bundle exec jekyll build
+  - rm -f ./_site/feed.xml
 deploy:
   provider: pages
   local-dir: ./_site

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem "minima" # , "~> 2.5"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-  gem "jekyll-feed", "~> 0.6"
   gem "json"
   gem "hash-joiner"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,6 @@ PLATFORMS
 
 DEPENDENCIES
   hash-joiner
-  jekyll-feed (~> 0.6)
   json
   minima
   tzinfo (~> 1.2)
@@ -87,4 +86,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   2.0.0
+   2.0.2

--- a/_config.yml
+++ b/_config.yml
@@ -63,7 +63,6 @@ minima:
 theme: minima
 
 plugins:
-#  - jekyll-feed
  - jekyll-seo-tag
 
 plugins_dir: ./_plugins


### PR DESCRIPTION
Removing the relevant gem from the `Gemfile` is not sufficient because
the `minima` theme depends on it. This hacks around it by still building
the `feed.xml` file, but then deleting it before deploying to GitHub via
Travis CI.